### PR TITLE
why do these tests pass?

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ inThisBuild(List(
   )
 ))
 
-val scala3Version = "3.0.1"
+val scala3Version = "3.3.1"
 
 val circeVersion = "0.14.1"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.5
+sbt.version = 1.10.1

--- a/src/test/scala/BinaryDeepNetworkTest.scala
+++ b/src/test/scala/BinaryDeepNetworkTest.scala
@@ -6,7 +6,7 @@ import synapses.lib._
 class BinaryDeepNetworkTest:
 
   // a "somewhat deep" network with 37 hidden layers and a single output
-  val layerSizesLarge = List(1024) ++ List.fill(37)(6) ++ List(1)
+  val layerSizesLarge = List(1024) ++ List.fill(67)(6) ++ List(1)
 
   // same input and output layers but with only one hidden layer
   val layerSizesSmall= List(1024) ++ List(6) ++ List(1)
@@ -22,19 +22,40 @@ class BinaryDeepNetworkTest:
 
   def activationF(layerIndex: Int): Fun =
     layerIndex match
-      case _ => Fun.sigmoid
+      case _ => Fun.leakyReLU
 
-  def weightInitF(_layerIndex: Int): Double =
+  def weightInitFlarge( layerIndex: Int): Double =
+    // Uniform Xavier Initialization
+    // https://365datascience.com/tutorials/machine-learning-tutorials/what-is-xavier-initialization/
+
+    // get the number of inputs and outputs for the layer in question
+    val (num_inputs, num_outputs) = layerIndex match 
+      case 0 => 
+        // input layer always has same number of inputs and outputs
+        (layerSizesLarge(0),layerSizesLarge(0))
+      case i if( i == layerSizesLarge.size - 1 ) => 
+        // output layer has inputs, but no outputs
+        (layerSizesLarge(layerIndex - 1), 0)
+      case i => 
+        // inner layers have num inputs from prev layer
+        (layerSizesLarge(layerIndex - 1), layerSizesLarge(layerIndex))
+    
+    // return weight selected uniformly from [-x,x]
+    val x = math.sqrt(6.0 / (num_inputs + num_outputs))
+    rand.between(-x,x)
+
+
+  def weightInitFsmall(_layerIndex: Int): Double =
     1.0 - 2.0 * rand.nextDouble()
 
-  val largeNet = Net(layerSizesLarge, activationF, weightInitF)
-  val smallNet = Net(layerSizesSmall, activationF, weightInitF)
+  val largeNet = Net(layerSizesLarge, activationF, weightInitFlarge)
+  val smallNet = Net(layerSizesSmall, activationF, weightInitFsmall)
 
   @Test def `inputs not equal`(): Unit = 
     assertNotEquals(input1, input2)
 
-  @Test def `same exact output for different inputs`(): Unit =
-    assertEquals(
+  @Test def `different inputs should give different outputs`(): Unit =
+    assertNotEquals(
       largeNet.parPredict(input1),
       largeNet.parPredict(input2)
     )

--- a/src/test/scala/BinaryDeepNetworkTest.scala
+++ b/src/test/scala/BinaryDeepNetworkTest.scala
@@ -26,7 +26,7 @@ class BinaryDeepNetworkTest:
     // note: if the hidden layer sizes are significantly smaller than the input layer there
     // may be too much information loss and this test may fail. The below parameters seem
     // to work.
-    val layerSizes = layerSizesF(num_hidden_layers = 700, num_neurons_per_hidden_layer = 300)
+    val layerSizes = layerSizesF(num_hidden_layers = 50, num_neurons_per_hidden_layer = 300)
 
     def activationF(layerIndex: Int): Fun =
       layerIndex match
@@ -59,6 +59,13 @@ class BinaryDeepNetworkTest:
       net.parPredict(input1),
       net.parPredict(input2)
     )
+
+    // is this network even trainable?
+    println("fitting to input1")
+    val fitted = net.parFit(0.1, input1, expectedOutput = List(0.0))
+    println("predicting from input2")
+    println(fitted.parPredict(input2))
+    println("done")
   
   @Test def `but smaller network properly gives different outputs`(): Unit =
     val layerSizes = layerSizesF(num_hidden_layers = 1, num_neurons_per_hidden_layer = 6)

--- a/src/test/scala/BinaryDeepNetworkTest.scala
+++ b/src/test/scala/BinaryDeepNetworkTest.scala
@@ -9,7 +9,7 @@ class BinaryDeepNetworkTest:
   def layerSizesF( num_hidden_layers: Int, num_neurons_per_hidden_layer:Int = 6) = 
     List(1024) ++ List.fill(num_hidden_layers)(num_neurons_per_hidden_layer) ++ List(1)
 
-  val rand = new Random(1000)
+  val rand = new Random(1070)
   private def randBits(n: Int) = List.range(0,n).map(_ => rand.nextBoolean())
   private def bool2Double(b: Boolean) = if(b) 1.0 else 0.0
 
@@ -23,8 +23,10 @@ class BinaryDeepNetworkTest:
 
   @Test def `different inputs should give different outputs`(): Unit =
     // a "somewhat deep" network
-    // even as few as 67 hidden layers seems to cause the test to fail every few tries
-    val layerSizes = layerSizesF(num_hidden_layers = 167, num_neurons_per_hidden_layer = 6)
+    // note: if the hidden layer sizes are significantly smaller than the input layer there
+    // may be too much information loss and this test may fail. The below parameters seem
+    // to work.
+    val layerSizes = layerSizesF(num_hidden_layers = 700, num_neurons_per_hidden_layer = 300)
 
     def activationF(layerIndex: Int): Fun =
       layerIndex match

--- a/src/test/scala/BinaryDeepNetworkTest.scala
+++ b/src/test/scala/BinaryDeepNetworkTest.scala
@@ -1,0 +1,46 @@
+import org.junit.Test
+import org.junit.Assert.*
+import scala.util.Random
+import synapses.lib._
+
+class BinaryDeepNetworkTest:
+
+  // a "somewhat deep" network with 37 hidden layers and a single output
+  val layerSizesLarge = List(1024) ++ List.fill(37)(6) ++ List(1)
+
+  // same input and output layers but with only one hidden layer
+  val layerSizesSmall= List(1024) ++ List(6) ++ List(1)
+
+  val rand = new Random(1000)
+  private def randBits(n: Int) = List.range(0,n).map(_ => rand.nextBoolean())
+  private def bool2Double(b: Boolean) = if(b) 1.0 else 0.0
+
+  // our inputs are bitvectors, so all input values are ether 0 or 1
+  // and these are mapped using above helpers accordingly to 0.0 and 1.0
+  val input1 = randBits(1024).map(bool2Double)
+  val input2 = randBits(1024).map(bool2Double)
+
+  def activationF(layerIndex: Int): Fun =
+    layerIndex match
+      case _ => Fun.sigmoid
+
+  def weightInitF(_layerIndex: Int): Double =
+    1.0 - 2.0 * rand.nextDouble()
+
+  val largeNet = Net(layerSizesLarge, activationF, weightInitF)
+  val smallNet = Net(layerSizesSmall, activationF, weightInitF)
+
+  @Test def `inputs not equal`(): Unit = 
+    assertNotEquals(input1, input2)
+
+  @Test def `same exact output for different inputs`(): Unit =
+    assertEquals(
+      largeNet.parPredict(input1),
+      largeNet.parPredict(input2)
+    )
+  
+  @Test def `but smaller network properly gives different outputs`(): Unit =
+    assertNotEquals(
+      smallNet.parPredict(input1),
+      smallNet.parPredict(input2)
+    )


### PR DESCRIPTION
@mrdimosthenis I was playing again with this excellent library recently and noticed something strange. Well, maybe it it is not strange and I simply do not know enough about how these neural nets work. Either way it is the following observation:

When trying to design a deep network with many hidden layers, the freshly initialized (untrained) network returns the same exact output for two _different_ inputs. This is very surprising to me and feels wrong. The inputs are 1024-bit vectors where each bit is encoded as either a 0.0 or a 1.0.

Why is this happening? Is it something to do with the number of parameters/weights being mashed together by the math such that the resulting value is a constant? Or is there something about the activation functions which I am not understanding?

Thank you in advance for your help.

(Ideally I would like to get to thousands of layers but the issue demonstrated in the tests happens even in as few as approximately 30 layers), 
